### PR TITLE
Fix typo: corrdinate -> coordinate.

### DIFF
--- a/build/scripts-3.7/CrossMap.py
+++ b/build/scripts-3.7/CrossMap.py
@@ -973,19 +973,19 @@ def crossmap_bed_file(mapping, inbed, outfile=None):
 		try:
 			int(fields[1])
 		except:
-			print("Start corrdinate is not an integer. skip " + line, file=sys.stderr)
+			print("Start coordinate is not an integer. skip " + line, file=sys.stderr)
 			if outfile:
 				print(line + '\tInvalidStartPosition', file=UNMAP)
 			continue
 		try:
 			int(fields[2])
 		except:
-			print("End corrdinate is not an integer. skip " + line, file=sys.stderr)
+			print("End coordinate is not an integer. skip " + line, file=sys.stderr)
 			if outfile:
 				print(line + '\tInvalidEndPosition', file=UNMAP)
 			continue
 		if int(fields[1]) > int(fields[2]):
-			print("\"Start\" is larger than \"End\" corrdinate is not an integer. skip " + line, file=sys.stderr)
+			print("\"Start\" is larger than \"End\" coordinate is not an integer. skip " + line, file=sys.stderr)
 			if outfile:
 				print(line + '\tStart>End', file=UNMAP)
 			continue

--- a/build/scripts-3.7/CrossMap_beta.py
+++ b/build/scripts-3.7/CrossMap_beta.py
@@ -992,19 +992,19 @@ def crossmap_bed_file(mapping, inbed, outfile=None, min_ratio = 0.95):
 		try:
 			int(fields[1])
 		except:
-			print("Start corrdinate is not an integer. skip " + line, file=sys.stderr)
+			print("Start coordinate is not an integer. skip " + line, file=sys.stderr)
 			if outfile:
 				print(line + '\tInvalidStartPosition', file=UNMAP)
 			continue
 		try:
 			int(fields[2])
 		except:
-			print("End corrdinate is not an integer. skip " + line, file=sys.stderr)
+			print("End coordinate is not an integer. skip " + line, file=sys.stderr)
 			if outfile:
 				print(line + '\tInvalidEndPosition', file=UNMAP)
 			continue
 		if int(fields[1]) > int(fields[2]):
-			print("\"Start\" is larger than \"End\" corrdinate is not an integer. skip " + line, file=sys.stderr)
+			print("\"Start\" is larger than \"End\" coordinate is not an integer. skip " + line, file=sys.stderr)
 			if outfile:
 				print(line + '\tStart>End', file=UNMAP)
 			continue

--- a/lib/cmmodule/mapbed.py
+++ b/lib/cmmodule/mapbed.py
@@ -45,19 +45,19 @@ def crossmap_bed_file(mapping, inbed, outfile=None):
 		try:
 			int(fields[1])
 		except:
-			print("Start corrdinate is not an integer. skip " + line, file=sys.stderr)
+			print("Start coordinate is not an integer. skip " + line, file=sys.stderr)
 			if outfile:
 				print(line + '\tInvalidStartPosition', file=UNMAP)
 			continue
 		try:
 			int(fields[2])
 		except:
-			print("End corrdinate is not an integer. skip " + line, file=sys.stderr)
+			print("End coordinate is not an integer. skip " + line, file=sys.stderr)
 			if outfile:
 				print(line + '\tInvalidEndPosition', file=UNMAP)
 			continue
 		if int(fields[1]) > int(fields[2]):
-			print("\"Start\" is larger than \"End\" corrdinate is not an integer. skip " + line, file=sys.stderr)
+			print("\"Start\" is larger than \"End\" coordinate is not an integer. skip " + line, file=sys.stderr)
 			if outfile:
 				print(line + '\tStart>End', file=UNMAP)
 			continue

--- a/lib/cmmodule/mapregion.py
+++ b/lib/cmmodule/mapregion.py
@@ -46,19 +46,19 @@ def crossmap_region_file(mapping, inbed, outfile=None, min_ratio = 0.85):
 		try:
 			int(fields[1])
 		except:
-			print("Start corrdinate is not an integer. skip " + line, file=sys.stderr)
+			print("Start coordinate is not an integer. skip " + line, file=sys.stderr)
 			if outfile:
 				print(line + '\tInvalidStartPosition', file=UNMAP)
 			continue
 		try:
 			int(fields[2])
 		except:
-			print("End corrdinate is not an integer. skip " + line, file=sys.stderr)
+			print("End coordinate is not an integer. skip " + line, file=sys.stderr)
 			if outfile:
 				print(line + '\tInvalidEndPosition', file=UNMAP)
 			continue
 		if int(fields[1]) > int(fields[2]):
-			print("\"Start\" is larger than \"End\" corrdinate is not an integer. skip " + line, file=sys.stderr)
+			print("\"Start\" is larger than \"End\" coordinate is not an integer. skip " + line, file=sys.stderr)
 			if outfile:
 				print(line + '\tStart>End', file=UNMAP)
 			continue


### PR DESCRIPTION
Hi Liguo!

Thanks for making CrossMap. This just fixes a typo in some of the warning messages.